### PR TITLE
update login on start browser test case and add decision for verify

### DIFF
--- a/Data Files/TestData.dat
+++ b/Data Files/TestData.dat
@@ -10,7 +10,7 @@
    <dataSourceUrl></dataSourceUrl>
    <driver>InternalData</driver>
    <data>John+Doe g3%2FDOGG74jC3Flrr3yH%2B3D%2FyKbOqqUNM Medicaid 23%2F11%2F2023 Tokyo+CURA+Healthcare+Center Yes Appoint+variation+1 Used+in+Main+Test+Case%2FTC03</data>
-   <data>John+Doe g3%2FDOGG74jC3Flrr3yH%2B3D%2FyKbOqqUNM Medicare 11%2F01%2F2024 Seoul+CURA+Healthcare+Center No Appoint+variation+2 Used+in+Main+Test+Case%2FTC04</data>
+   <data>John+Doe g3%2FDOGG74jC3Flrr3yH%2B3D%2FyKbOqqUNM null 11%2F01%2F2024 Seoul+CURA+Healthcare+Center No Appoint+variation+2 Used+in+Main+Test+Case%2FTC04</data>
    <data>Johndoe g3%2FDOGG74jC3Flrr3yH%2B3D%2FyKbOqqUNM null null null null null For+invalid+username+login</data>
    <data>John+Doe b%2F98lgFmTtuLvynNFOQHnA%3D%3D null null null null null For+invalid+password+login</data>
    <data>John+Doe g3%2FDOGG74jC3Flrr3yH%2B3D%2FyKbOqqUNM null null null null null Universal+valid+user</data>

--- a/Scripts/Component/Browser Related/Start Browser and Head to URL/Script1699685968204.groovy
+++ b/Scripts/Component/Browser Related/Start Browser and Head to URL/Script1699685968204.groovy
@@ -17,9 +17,7 @@ import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
 import internal.GlobalVariable as GlobalVariable
 import org.openqa.selenium.Keys as Keys
 
-WebUI.openBrowser('')
+WebUI.openBrowser('https://katalon-demo-cura.herokuapp.com/')
 
 WebUI.maximizeWindow()
-
-WebUI.navigateToUrl('https://katalon-demo-cura.herokuapp.com/')
 

--- a/Scripts/Component/Common/Verify Appointment after Submitting/Script1699711587200.groovy
+++ b/Scripts/Component/Common/Verify Appointment after Submitting/Script1699711587200.groovy
@@ -23,8 +23,16 @@ WebUI.verifyMatch(facilityName, WebUI.getText(findTestObject('Page_CURAHealth_Ap
 WebUI.verifyMatch(isReadmission, WebUI.getText(findTestObject('Page_CURAHealth_Appointment Verification/label_ReadmissionStatus')), 
     false)
 
-WebUI.verifyMatch(programName, WebUI.getText(findTestObject('Page_CURAHealth_Appointment Verification/label_ProgramName')), 
-    false)
+'To mitigate in case other tester did not put "None" in Test Data'
+if (programName == '') {
+    'Automation will automatically use "None" to verify Program Name field on Appointment Success page'
+    WebUI.verifyMatch('None', WebUI.getText(findTestObject('Page_CURAHealth_Appointment Verification/label_ProgramName')), 
+        false)
+} else {
+    'Else, if it found that programName contains string (e.g. Medicaid), it will use said string to compare'
+    WebUI.verifyMatch(programName, WebUI.getText(findTestObject('Page_CURAHealth_Appointment Verification/label_ProgramName')), 
+        false)
+}
 
 WebUI.verifyMatch(visitDate, WebUI.getText(findTestObject('Page_CURAHealth_Appointment Verification/label_VisitationDate')), 
     false)

--- a/Scripts/Component/Common/Verify History/Script1699882364937.groovy
+++ b/Scripts/Component/Common/Verify History/Script1699882364937.groovy
@@ -23,8 +23,16 @@ WebUI.verifyMatch(facilityName, WebUI.getText(findTestObject('Page_CURAHistory/l
 WebUI.verifyMatch(isReadmission, WebUI.getText(findTestObject('Page_CURAHistory/label_readmissionStatus', [('occurence') : occurence])), 
     false)
 
-WebUI.verifyMatch(programName, WebUI.getText(findTestObject('Page_CURAHistory/label_programName', [('occurence') : occurence])), 
-    false)
+'To mitigate in case other tester did not put "None" in Test Data'
+if (programName == '') {
+    'Automation will automatically use "None" to verify Program Name field on Appointment Success page'
+    WebUI.verifyMatch('None', WebUI.getText(findTestObject('Page_CURAHistory/label_programName', [('occurence') : occurence])), 
+        false)
+} else {
+    'Else, if it found that programName contains string (e.g. Medicaid), it will use said string to compare'
+    WebUI.verifyMatch(programName, WebUI.getText(findTestObject('Page_CURAHistory/label_programName', [('occurence') : occurence])), 
+        false)
+}
 
 WebUI.verifyMatch(visitDate, WebUI.getText(findTestObject('Page_CURAHistory/label_visitationDate', [('occurence') : occurence])), 
     false)


### PR DESCRIPTION
*Login script on Start Browser test case updated. Rather than using separate keyword to open the URL, it is changed to directly use built-in feature on Start Browser keyword

*Add decision statement for Verify History and Verify Appointment after Submitting component. In case someone forget to put "None" on Test Data for Program Name. With this statement, the automation won't end up in failure due to this. Yes, it will be much easier to tell others to not forget to put "None" on the test data but do you trust them to remember this later down the line? Heck, will you also still remember? Hence it would be easier to just put decision statement there

