### PR TITLE
update start browser to use global variable for url

### DIFF
--- a/Scripts/Component/Browser Related/Start Browser and Head to URL/Script1699685968204.groovy
+++ b/Scripts/Component/Browser Related/Start Browser and Head to URL/Script1699685968204.groovy
@@ -17,7 +17,7 @@ import com.kms.katalon.core.windows.keyword.WindowsBuiltinKeywords as Windows
 import internal.GlobalVariable as GlobalVariable
 import org.openqa.selenium.Keys as Keys
 
-WebUI.openBrowser('https://katalon-demo-cura.herokuapp.com/')
+WebUI.openBrowser(GlobalVariable.webURL)
 
 WebUI.maximizeWindow()
 


### PR DESCRIPTION
forgot to use global variable instead for URL destination in Start Browser script. rather not let that Global Variable be useless